### PR TITLE
support timestamps from non-git repos

### DIFF
--- a/R/build.R
+++ b/R/build.R
@@ -59,7 +59,7 @@ build_pkg <- function(.pkgdir = ".",
         timestamp = as.integer(supplement_version),
         Version = sprintf("%s.%s", version, supplement_version)
       )
-      meta <- modifyList(meta, hs)
+      meta <- modifyList(meta, sv)
     } else if (supplement_version) {
       hs <- hashstamp()
       version <- d__$get_version()

--- a/R/build.R
+++ b/R/build.R
@@ -24,7 +24,9 @@ modify_desc <- function(.d, meta, loc, overwrite = TRUE) {
 #' @param repository repository name being built for
 #' @param origin package source
 #' @param addl_meta additional metadata
-#' @param supplement_version whether to add additional version info (unix timestamp)
+#' @param supplement_version add additional version info (unix timestamp) to version.
+#' TRUE inspects the pkg folder as a git repo, also may provide a character or numeric
+#' value to append
 #' @param overwrite overwrite fields already present when adding fields
 #' @param ... parameters to pass to pkgbuild
 #' @details
@@ -32,7 +34,7 @@ modify_desc <- function(.d, meta, loc, overwrite = TRUE) {
 #' correspond to a formal release/tag. This will automatically add information
 #' about the git hash (if available), as well as incrememnt the version number
 #' with a unix timestamp that corresponds to the last git hash (if present) or
-#' the current system time, if git is not present.
+#' the current system time, if git is not present and no version timestamp is provided.
 #' @importFrom stats setNames
 #' @importFrom utils modifyList
 #' @export
@@ -51,7 +53,14 @@ build_pkg <- function(.pkgdir = ".",
     if (!is.null(addl_meta)) {
       meta <- modifyList(meta, addl_meta)
     }
-    if (supplement_version) {
+    if (is.numeric(supplement_version) || is.character(supplement_version)) {
+      version <- d__$get_version()
+      sv <- list(
+        timestamp = as.integer(supplement_version),
+        Version = sprintf("%s.%s", version, supplement_version)
+      )
+      meta <- modifyList(meta, hs)
+    } else if (supplement_version) {
       hs <- hashstamp()
       version <- d__$get_version()
       hs$Version <- sprintf("%s.%s", version, hs$timestamp)

--- a/man/build_pkg.Rd
+++ b/man/build_pkg.Rd
@@ -19,7 +19,9 @@ build_pkg(.pkgdir = ".", types = c("source", "binary"),
 
 \item{addl_meta}{additional metadata}
 
-\item{supplement_version}{whether to add additional version info (unix timestamp)}
+\item{supplement_version}{add additional version info (unix timestamp) to version.
+TRUE inspects the pkg folder as a git repo, also may provide a character or numeric
+value to append}
 
 \item{overwrite}{overwrite fields already present when adding fields}
 
@@ -33,5 +35,5 @@ supplementing version can be done whenever a build occurs that does not
 correspond to a formal release/tag. This will automatically add information
 about the git hash (if available), as well as incrememnt the version number
 with a unix timestamp that corresponds to the last git hash (if present) or
-the current system time, if git is not present.
+the current system time, if git is not present and no version timestamp is provided.
 }


### PR DESCRIPTION
this will allow packages to be built with new version stamps when not actually in a git repository

one use case for this is when downloading package tarballs or pulling from api's to put into a cranlike repo.
